### PR TITLE
Improve parsing of multi-file names based on last underscore

### DIFF
--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -100,17 +100,21 @@ def copy_header(header, file_in, file_out):
 
 
 def get_multi_files(params):
-    file_name   = params.get('data', 'data_multi_file')
-    dirname     = os.path.abspath(os.path.dirname(file_name))
-    all_files   = os.listdir(dirname)
-    pattern     = os.path.basename(file_name)
-    to_process  = []
-    count       = 0
+    file_name       = params.get('data', 'data_multi_file')
+    dirname         = os.path.abspath(os.path.dirname(file_name))
+    all_files       = os.listdir(dirname)
+    fname           = os.path.basename(file_name)
+    fn, ext         = os.path.splitext(fname)
+    head, sep, tail = fn.rpartition('_')
+    mindigits       = len(tail)
+    basefn, fnum    = head, int(tail)
+    to_process      = []
 
-    while pattern in all_files:
-        to_process += [os.path.join(os.path.abspath(dirname), pattern)]
-        pattern     = pattern.replace(str(count), str(count+1))
-        count      += 1
+    while fname in all_files:
+        to_process += [os.path.join(os.path.abspath(dirname), fname)]
+        fnum       += 1
+        fmtstring   = '_%%0%dd%%s' % mindigits
+        fname       = basefn + fmtstring % (fnum, ext)
 
     print_and_log(['Multi-files:'] + to_process, 'debug', params)
     return to_process
@@ -300,8 +304,11 @@ def load_parameters(file_name):
 
     if parser.getboolean('data', 'multi-files'):
         parser.set('data', 'data_multi_file', file_name)
-        pattern     = os.path.basename(file_name).replace('0', 'all')
-        multi_file  = os.path.join(file_path, pattern)
+        fname = os.path.basename(file_name)
+        fn, ext = os.path.splitext(fname)
+        head, sep, tail = fn.rpartition('_')
+        mfname = head + sep + 'all' + ext # replace file number with 'all'
+        multi_file = os.path.join(file_path, mfname)
         parser.set('data', 'data_file', multi_file)
         f_next, extension = os.path.splitext(multi_file)
     else:

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -108,12 +108,12 @@ def get_multi_files(params):
     head, sep, tail = fn.rpartition('_')
     mindigits       = len(tail)
     basefn, fnum    = head, int(tail)
+    fmtstring       = '_%%0%dd%%s' % mindigits
     to_process      = []
 
     while fname in all_files:
         to_process += [os.path.join(os.path.abspath(dirname), fname)]
         fnum       += 1
-        fmtstring   = '_%%0%dd%%s' % mindigits
         fname       = basefn + fmtstring % (fnum, ext)
 
     print_and_log(['Multi-files:'] + to_process, 'debug', params)


### PR DESCRIPTION
This improves parsing of multi-file names. File numbers no longer have to start from 0, can now have leading 0s, and are now more carefully parsed from the file names, based on everything between the last _ and the file extension, as implied in the documentation [here](http://spyking-circus.readthedocs.io/en/latest/code/multifiles.html).

I know there's a big rewrite happening right now which this will conflict with, but in the mean time, I find this quite useful, given the naming scheme of our data files, which is something like:

`my_file_name_01.dat, my_file_name_02.dat, ...`