### PR TITLE
Trig unit can be specified in timsteps

### DIFF
--- a/changelog
+++ b/changelog
@@ -8,6 +8,7 @@ Release 0.5
 * cosmetic changes in the clustering plots
 * ordering of the channels in the openephys wrapper
 * fix for rates in the MATLAB GUI
+* artefacts can now be given in ms or in timesteps with the trig_unit parameter
 
 
 =============

--- a/circus/config.params
+++ b/circus/config.params
@@ -25,8 +25,9 @@ filter         = True       # If True, then a low-pass filtering is performed
 remove_median  = False      # If True, median over all channels is substracted to each channels (movement artifacts)
 
 [triggers]
-trig_file      =            # If external stimuli need to be considered as putative artefacts (see documentation)
-trig_windows   =            # The time windows of those external stimuli [in ms]
+trig_file      =            # External stimuli to be considered as putative artefacts [in trig units] (see documentation) 
+trig_windows   =            # The time windows of those external stimuli [in trig units]
+trig_unit      = ms         # The unit in which times are expressed: can be either ms or timestep
 clean_artefact = False      # If True, external artefacts induced by triggers will be suppressed from data
 make_plots     =            # Generate sanity plots of the averaged artefacts [Nothing or None if no plots]
 

--- a/circus/filtering.py
+++ b/circus/filtering.py
@@ -108,6 +108,7 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
     def compute_artefacts(data_file):
 
         chunk_size     = params.getint('data', 'chunk_size')
+        trig_in_ms     = params.getboolean('triggers', 'trig_in_ms')
         artefacts      = numpy.loadtxt(params.get('triggers', 'trig_file'))
         windows        = numpy.loadtxt(params.get('triggers', 'trig_windows'))
         make_plots     = params.get('triggers', 'make_plots')
@@ -116,8 +117,13 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
         if len(windows.shape) == 1:
             windows = windows.reshape(1, 2)
 
-        artefacts[:, 1] *= numpy.int64(data_file.sampling_rate*1e-3)
-        windows[:, 1]   *= numpy.int64(data_file.sampling_rate*1e-3)
+        if trig_in_ms:
+            artefacts[:, 1] *= numpy.int64(data_file.sampling_rate*1e-3)
+            windows[:, 1]   *= numpy.int64(data_file.sampling_rate*1e-3)
+        else:
+            artefacts        = artefact.astype(numpy.int64)
+            windows          = windows.astype(numpy.int64)
+
         nb_stimuli       = len(numpy.unique(artefacts[:, 0]))
         mytest           = nb_stimuli == len(windows)
 
@@ -168,6 +174,7 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
     def remove_artefacts(data_file, art_dict):
 
         chunk_size     = params.getint('data', 'chunk_size')
+        trig_in_ms     = params.getboolean('triggers', 'trig_in_ms')
         artefacts      = numpy.loadtxt(params.get('triggers', 'trig_file')).astype(numpy.int64)
         windows        = numpy.loadtxt(params.get('triggers', 'trig_windows')).astype(numpy.int64)
         make_plots     = params.get('triggers', 'make_plots')
@@ -176,8 +183,13 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
         if len(windows.shape) == 1:
             windows = windows.reshape(1, 2)
 
-        artefacts[:, 1] *= numpy.int64(data_file.sampling_rate*1e-3)
-        windows[:, 1]   *= numpy.int64(data_file.sampling_rate*1e-3)
+        if trig_in_ms:
+            artefacts[:, 1] *= numpy.int64(data_file.sampling_rate*1e-3)
+            windows[:, 1]   *= numpy.int64(data_file.sampling_rate*1e-3)
+        else:
+            artefacts        = artefact.astype(numpy.int64)
+            windows          = windows.astype(numpy.int64)
+ 
         nb_stimuli       = len(numpy.unique(artefacts[:, 0]))
         mytest           = nb_stimuli == len(windows)
 

--- a/circus/filtering.py
+++ b/circus/filtering.py
@@ -118,10 +118,14 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
             windows = windows.reshape(1, 2)
 
         if trig_in_ms:
+            if comm.rank == 0:
+                print_and_log(['Artefact times are read in ms'], 'debug', logger)
             artefacts[:, 1] *= numpy.int64(data_file.sampling_rate*1e-3)
             windows[:, 1]   *= numpy.int64(data_file.sampling_rate*1e-3)
         else:
-            artefacts        = artefact.astype(numpy.int64)
+            if comm.rank == 0:
+                print_and_log(['Artefact times are read in timesteps'], 'debug', logger)
+            artefacts        = artefacts.astype(numpy.int64)
             windows          = windows.astype(numpy.int64)
 
         nb_stimuli       = len(numpy.unique(artefacts[:, 0]))
@@ -184,10 +188,14 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
             windows = windows.reshape(1, 2)
 
         if trig_in_ms:
+            if comm.rank == 0:
+                print_and_log(['Artefact times are read in ms'], 'debug', logger)
             artefacts[:, 1] *= numpy.int64(data_file.sampling_rate*1e-3)
             windows[:, 1]   *= numpy.int64(data_file.sampling_rate*1e-3)
         else:
-            artefacts        = artefact.astype(numpy.int64)
+            if comm.rank == 0:
+                print_and_log(['Artefact times are read in timesteps'], 'debug', logger)
+            artefacts        = artefacts.astype(numpy.int64)
             windows          = windows.astype(numpy.int64)
  
         nb_stimuli       = len(numpy.unique(artefacts[:, 0]))

--- a/circus/shared/parser.py
+++ b/circus/shared/parser.py
@@ -30,6 +30,7 @@ class CircusParser(object):
                           ['triggers', 'make_plots', 'string', 'png'],
                           ['triggers', 'trig_file', 'string', ''],
                           ['triggers', 'trig_windows', 'string', ''],
+                          ['triggers', 'trig_unit', 'string', 'ms'],
                           ['whitening', 'chunk_size', 'int', '30'],
                           ['filtering', 'remove_median', 'bool', 'False'],
                           ['clustering', 'max_clusters', 'int', '10'],
@@ -179,7 +180,16 @@ class CircusParser(object):
                 if comm.rank == 0:
                     print_and_log(["trig_file and trig_windows must be specified in [triggers]"], 'error', logger)
                 sys.exit(1)
-	    
+
+        units = ['ms', 'timestep']
+        test = self.parser.get('triggers', 'trig_unit').lower() in units
+        if not test:
+          if comm.rank == 0:
+              print_and_log(["trig_unit in [%triggers] should be in %s" %str(units)], 'error', logger)
+          sys.exit(1)
+        else:
+          self.parser.set('triggers', 'trig_in_ms', str(self.parser.get('triggers', 'trig_unit').lower() == 'ms'))
+    
         self.parser.set('triggers', 'trig_file', os.path.abspath(os.path.expanduser(self.parser.get('triggers', 'trig_file'))))
         self.parser.set('triggers', 'trig_windows', os.path.abspath(os.path.expanduser(self.parser.get('triggers', 'trig_windows'))))
 
@@ -258,7 +268,7 @@ class CircusParser(object):
             if comm.rank == 0:
                 print_and_log(["min and max dispersions in [clustering] should be positive"], 'error', logger)
             sys.exit(1)
-	        
+        
 
         pcs_export = ['prompt', 'none', 'all', 'some']
         test = self.parser.get('converting', 'export_pcs').lower() in pcs_export

--- a/circus/shared/parser.py
+++ b/circus/shared/parser.py
@@ -185,7 +185,7 @@ class CircusParser(object):
         test = self.parser.get('triggers', 'trig_unit').lower() in units
         if not test:
           if comm.rank == 0:
-              print_and_log(["trig_unit in [%triggers] should be in %s" %str(units)], 'error', logger)
+              print_and_log(["trig_unit in [triggers] should be in %s" %str(units)], 'error', logger)
           sys.exit(1)
         else:
           self.parser.set('triggers', 'trig_in_ms', str(self.parser.get('triggers', 'trig_unit').lower() == 'ms'))

--- a/docs_sphinx/code/artefacts.rst
+++ b/docs_sphinx/code/artefacts.rst
@@ -7,24 +7,27 @@ Sometimes, because of external stimulation, you may end up having some artefacts
 Specifying the stimulation times
 --------------------------------
 
-In a first text file, you must specify all the times of your artefacts, identified by a given identifier. For example, imagine you have 2 different stimulation protocols, each one inducing a different artefact. The text file will look like::
+In a first text file, you must specify all the times of your artefacts, identified by a given identifier. The times can be given in ms or in timesteps, and this can be changed with the ``trig_unit`` parameter. By default, they are assumed to be in ms. For example, imagine you have 2 different stimulation protocols, each one inducing a different artefact. The text file will look like::
 	
-	0 500
-	1 1000
-	0 1500
-	1 2000
+	0 500.2 
+	1 1000.2
+	0 1500.3
+	1 2000.1
 	...
+	0 27364.1
+	1 80402.4
 
-This means that stim 0 is displayed at 500ms, then stim 1 at 1000ms, and so on. All times in the text file are in ms, and you must use one line per time.
+This means that stim 0 is displayed at 500.2ms, then stim 1 at 1000.2ms, and so on. All times in the text file are in ms, and you must use one line per time. Use ``trig_unit`` if you want to give times in timesteps.
 
 Specifying the time windows
 ---------------------------
 
-In a second text file, you must tell the algorithm what is the time window you want to consider for a given artefact. Using the same example, and assuming that stim 0 produces an artefact of 100ms, while stim 1 produces a longer artefact of 500ms, the file should look like::
+In a second text file, you must tell the algorithm what is the time window you want to consider for a given artefact. Using the same example, and assuming that stim 0 produces an artefact of 100ms, while stim 1 produces a longer artefact of 510ms, the file should look like::
 
 	0 100
-	1 500
+	1 510
 
+Here, again, use ``trig_unit`` if you want to provide times in timesteps.
 
 How to use it
 -------------

--- a/docs_sphinx/code/config.rst
+++ b/docs_sphinx/code/config.rst
@@ -74,6 +74,7 @@ The triggers section is::
     trig_file      =           # If external stimuli need to be considered as putative artefacts (see documentation)
     trig_windows   =           # The time windows of those external stimuli [in ms]
     clean_artefact = False     # If True, external artefacts induced by triggers will be suppressed from data 
+    trig_unit      = ms        # The unit in which times are expressed: can be either ms or timestep
     make_plots     =           # Generate sanity plots of the averaged artefacts [Nothing or None if no plots]
 
 Parameters that are most likely to be changed:
@@ -81,7 +82,7 @@ Parameters that are most likely to be changed:
     * ``trig_windows`` The path to file where your artefact temporal windows. See :doc:`how to deal with stimulation artefacts <../code/artefacts>`
     * ``clean_artefact`` If you want to remove any stimulation artefacts, defined in the previous file. See :doc:`how to deal with stimulation artefacts <../code/artefacts>`
     * ``make_plots`` The default format to save the plots of the artefacts, one per artefact, showing all channels. You can set it to None if you do not want any
-
+    * ``trig_unit`` If you want times/duration in the ``trig_file`` and ``trig_windows`` to be in timestep or ms
 
 Whitening
 ---------


### PR DESCRIPTION
Addition of a trig_unit flag in the [triggers] section, that will say if trig times/durations are in ms or timesteps. In the future, default will be switch to timesteps for the sake of clarity