### PR TITLE
Fix upload logic for Pypi packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,10 +71,10 @@ after_test:
   - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if "%APPVEYOR_REPO_NAME%" == "spyking-circus/spyking-circus" if "%APPVEYOR_REPO_TAG%" == "true" (
       conda install --yes --quiet anaconda-client &&
       conda install --yes --quiet -c conda-forge twine &&
-      python packaging_tools\conda-server-push.py %APPVEYOR_REPO_TAG_NAME% &&
-      if "%PYPI_UPLOAD_SOURCE%" == "yes" (twine upload -u pierre.yger --skip-existing dist/*.tar.bz2) &&
-      if "%PYPI_UPLOAD_WHEEL%" == "yes" (twine upload -u pierre.yger --skip-existing dist/*.whl)
-    )'
+      python packaging_tools\conda-server-push.py %APPVEYOR_REPO_TAG_NAME%
+     )'
+  - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if "%APPVEYOR_REPO_NAME%" == "spyking-circus/spyking-circus" if "%APPVEYOR_REPO_TAG%" == "true" if "%PYPI_UPLOAD_SOURCE%" == "yes" (twine upload -u pierre.yger --skip-existing dist/*.tar.bz2)'
+  - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if "%APPVEYOR_REPO_NAME%" == "spyking-circus/spyking-circus" if "%APPVEYOR_REPO_TAG%" == "true" if "%PYPI_UPLOAD_WHEEL%" == "yes" (twine upload -u pierre.yger --skip-existing dist/*.whl)'
 
 artifacts:
   # Archive the generated conda package in the ci.appveyor.com build report.


### PR DESCRIPTION
My logic in the appveyor file was flawed, so that it would only upload the wheel if it also uploaded the source from the same job. This led to no wheel being uploaded for Python 2 (because the source was uploaded from the Python 3 job). Again, we will only see whether this actually works correctly with the next release, but I don't think we need a release for this right now (@yger already uploaded the file manually for this release).

PS: One can probably write that stuff more succinctly, but my Windows Batch file foo is not that strong...