### PR TITLE
Use conda-build from conda-forge for building the conda package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
 
 # command to install dependencies
 install:
-  - conda install --yes --quiet conda-build setuptools wheel
+  - conda install --yes --quiet -c conda-forge conda-build setuptools wheel
 
 # command to run tests
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ install:
 build: false  # not a C# project
 
 test_script:
-  - conda install --yes --quiet conda-build
+  - conda install --yes --quiet -c conda-forge conda-build
   - conda build -c spyking-circus -c conda-forge conda_recipe
   - python packaging_tools/move_conda_package.py
   - conda install --yes --quiet wheel


### PR DESCRIPTION
There seems to be a weird bug with the latest conda-build under Windows, where it *first* executes the tests and *then* performs the proper build/test phase. Somehow, this together with the version of matplotlib that is pre-installed on appveyor, made previous builds fail.
This PR uses the conda-build version from conda-forge, which is less often updated and should be therefore be more stable so that we hopefully we have to deal with this type of bug less often in the future.