### PR TITLE
Artifact removal fix

### DIFF
--- a/circus/filtering.py
+++ b/circus/filtering.py
@@ -228,7 +228,7 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
         for count, time in enumerate(all_times):
 
             label = all_labels[count]
-            tmp   = numpy.where(windows[:, 0] == label)[0]
+            tmp   = numpy.where(windows[:, 0] == label)[0][0]
             tau   = numpy.int64(windows[tmp, 1])
 
             if (data_file.t_stop - time) < tau:


### PR DESCRIPTION
There seemed to be a small problem with `tau` being expressed as an array instead of scalar as needed.

Previously numpy.where returns a 2d array, so `tmp` is a 1d array, so finally `windows[tmp, 1]` also returns a 1d array. At least in numpy 1.12.1, `numpy.int64()` is not returning a scalar and as a result, `tau` was represented as an int64 array instead of scalar. As an array, tau couldn't be used in the expression:

```local_chunk[:, i] -= art_dict[label][idx, :tau]```

This fix makes tmp scalar. When tmp is used to get an index, this now returns a scalar value for tau.