### PR TITLE
solves bug when extraction='mean-raw'

### DIFF
--- a/circus/clustering.py
+++ b/circus/clustering.py
@@ -904,7 +904,7 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
                     elif extraction == 'mean-raw':                
                         labels_i        = numpy.random.permutation(myslice)[:min(len(myslice), 250)]
                         times_i         = numpy.take(loc_times, labels_i)
-                        sub_data        = io.get_stas(sub_data, times_i, labels_i, ielec, neighs=indices, nodes=nodes, pos=p)
+                        sub_data        = io.get_stas(params, times_i, labels_i, ielec, neighs=indices, nodes=nodes, pos=p)
                         first_component = numpy.mean(sub_data, 0)
                         tmp_templates   = first_component
 


### PR DESCRIPTION
wrong variable assigned prompted an error when mean-raw was used [clustering] in the *params file