### PR TITLE
add docstrings to document the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv
 # General backup/temporary files
 *~
 *.bak
+*.swp
 
 # Generated SSH
 .#*

--- a/circus/config.params
+++ b/circus/config.params
@@ -1,17 +1,7 @@
-#=========================================================================
-# config.params
-#
-# Note that depending on the file format selected, the parameters in the 
-# data section can vary
-# You should refer to the documentation to know what are the needed 
-# parameters for a give file format. Otherwise, launch the code and a 
-# message will tell you what is needed
-#
-#=========================================================================
+### Note that depending on the file format selected, the parameters in the data section can vary
+### You should refer to the documentation to know what are the needed parameters for a given
+### file format. Otherwise, launch the code and a message will tell you what is needed
 
-#=========================================================================
-# data
-#=========================================================================
 [data]
 file_format    =                       # Can be raw_binary, openephys, hdf5, ... See >> spyking-circus help -i for more info
 stream_mode    = None                  # None by default. Can be multi-files, or anything depending to the file format
@@ -21,29 +11,20 @@ overwrite      = True                  # Filter or remove artefacts on site (if 
 parallel_hdf5  = True                  # Use the parallel HDF5 feature (if available)
 output_dir     =                       # By default, generated data are in the same folder as the data.
 
-#=========================================================================
-# detection 
-#=========================================================================
 [detection]
 radius         = auto       # Radius [in um] (if auto, read from the prb file)
-N_t            = 3          # Width of the templates [in ms]
+N_t            = auto       # Width of the templates [in ms] (if auto, adjusted while whitening)
 spike_thresh   = 6          # Threshold for spike detection
 peaks          = negative   # Can be negative (default), positive or both
 alignment      = True       # Realign the waveforms by oversampling
 dead_channels  =            # If not empty or specified in the probe, a dictionary {channel_group : [list_of_valid_ids]}
 
-#=========================================================================
-# filtering 
-#=========================================================================
 [filtering]
 cut_off        = 300, auto  # Min and Max (auto=nyquist) cut off frequencies for the band pass butterworth filter [Hz]
 filter         = True       # If True, then a low-pass filtering is performed
 remove_median  = False      # If True, median over all channels is substracted to each channels (movement artifacts)
 common_ground  =            # If you want to use a particular channel as a reference ground: should be a channel number
 
-#=========================================================================
-# triggers 
-#=========================================================================
 [triggers]
 trig_file      =            # External stimuli to be considered as putative artefacts [in trig units] (see documentation)
 trig_windows   =            # The time windows of those external stimuli [in trig units]
@@ -54,25 +35,15 @@ dead_unit      = ms         # The unit in which times for dead regions are expre
 ignore_times   = False      # If True, any spike in the dead regions will be ignored by the analysis
 make_plots     =            # Generate sanity plots of the averaged artefacts [Nothing or None if no plots]
 
-#=========================================================================
-# whitening 
-#=========================================================================
 [whitening]
-chunk_size     = 30         # Size of the data chunks [in s]
-safety_time    = auto       # Temporal zone around which templates are isolated [in ms, or auto]
 spatial        = True       # Perform spatial whitening
 max_elts       = 1000       # Max number of events per electrode (should be compatible with nb_elts)
 nb_elts        = 0.8        # Fraction of max_elts that should be obtained per electrode [0-1]
 output_dim     = 5          # Can be in percent of variance explain, or num of dimensions for PCA on waveforms
 
-#=========================================================================
-# clustering 
-#=========================================================================
 [clustering]
 extraction     = median-raw # Can be either median-raw (default), median-pca, mean-pca, mean-raw
 sub_dim        = 10         # Number of dimensions to keep for local PCA per electrode
-safety_space   = True       # If True, we exclude spikes in the vicinity of a selected spikes
-safety_time    = auto       # Temporal zone around which templates are isolated [in ms, or auto]
 max_elts       = 10000      # Max number of events per electrode (should be compatible with nb_elts)
 nb_elts        = 0.8        # Fraction of max_elts that should be obtained per electrode [0-1]
 nclus_min      = 0.005      # Min number of elements in a cluster (given in percentage) [0-1]
@@ -83,24 +54,13 @@ dip_threshold  = 0.5        # Will replace sim_same_elec in the future. Set it t
 sensitivity    = 3          # Single parameter for clustering sensitivity. The lower the more sensitive
 cc_merge       = 0.975      # If CC between two templates is higher, they are merged
 dispersion     = (5, 5)     # Min and Max dispersion allowed for amplitudes [in MAD]
-noise_thr      = 0.8        # Minimal amplitudes are such than amp*min(templates) < noise_thr*threshold in [0-1]
-remove_mixture = True       # At the end of the clustering, we remove mixtures of templates
-cc_mixtures    = 0.75       # If CC between a sum of two templates and a template is higher, it is removed
 make_plots     =            # Generate sanity plots of the clustering [Nothing or None if no plots]
 
-#=========================================================================
-# fitting 
-#=========================================================================
 [fitting]
-chunk_size     = 1          # Size of chunks used during fitting [in second]
 amp_limits     = (0.3, 5)   # Amplitudes for the templates during spike detection [if not auto]
 amp_auto       = True       # True if amplitudes are adjusted automatically for every templates
-max_chunk      = inf        # Fit only up to max_chunk
 collect_all    = False      # If True, one garbage template per electrode is created, to store unfitted spikes
 
-#=========================================================================
-# merging 
-#=========================================================================
 [merging]
 cc_overlap     = 0.85       # Only templates with CC higher than cc_overlap may be merged
 cc_bin         = 2          # Bin size for computing CC [in ms]
@@ -109,9 +69,6 @@ default_lag    = 5          # Default length of the period to compute dip in the
 auto_mode      = 0.75       # Between 0 (aggressive) and 1 (no merging). If empty, GUI is launched
 remove_noise   = False      # If True, meta merging will remove obvious noise templates (weak amplitudes)
 
-#=========================================================================
-# converting 
-#=========================================================================
 [converting]
 erase_all      = True       # If False, a prompt will ask you to export if export has already been done
 export_pcs     = prompt     # Can be prompt [default] or in none, all, some
@@ -119,9 +76,6 @@ export_all     = False      # If True, unfitted spikes will be exported as the l
 sparse_export  = True       # For recent versions of phy, and large number of templates/channels
 prelabelling   = False      # If True, putative labels (good, noise, best, mua) are pre-assigned to neurons
 
-#=========================================================================
-# validating 
-#=========================================================================
 [validating]
 nearest_elec   = auto       # Validation channel (e.g. electrode closest to the ground truth cell)
 max_iter       = 200        # Maximum number of iterations of the stochastic gradient descent (SGD)
@@ -136,9 +90,6 @@ juxta_spikes   =            # If none, spikes are automatically detected based o
 filter         = True       # If the juxta channel need to be filtered or not
 make_plots     = png        # Generate sanity plots of the validation [Nothing or None if no plots]
 
-#=========================================================================
-# extracting 
-#=========================================================================
 [extracting]
 safety_time    = 1          # Temporal zone around which spikes are isolated [in ms]
 max_elts       = 1000       # Max number of collected events per templates
@@ -146,9 +97,6 @@ output_dim     = 5          # Percentage of variance explained while performing 
 cc_merge       = 0.975      # If CC between two templates is higher, they are merged
 noise_thr      = 0.8        # Minimal amplitudes are such than amp*min(templates) < noise_thr*threshold
 
-#=========================================================================
-# noedits will be writing by spyking-circus 
-#=========================================================================
 [noedits]
 filter_done    = False      # Will become True automatically after filtering
 artefacts_done = False      # Will become True automatically after removing artefacts

--- a/circus/config.params
+++ b/circus/config.params
@@ -1,7 +1,17 @@
-### Note that depending on the file format selected, the parameters in the data section can vary
-### You should refer to the documentation to know what are the needed parameters for a given
-### file format. Otherwise, launch the code and a message will tell you what is needed
+#=========================================================================
+# config.params
+#
+# Note that depending on the file format selected, the parameters in the 
+# data section can vary
+# You should refer to the documentation to know what are the needed 
+# parameters for a give file format. Otherwise, launch the code and a 
+# message will tell you what is needed
+#
+#=========================================================================
 
+#=========================================================================
+# data
+#=========================================================================
 [data]
 file_format    =                       # Can be raw_binary, openephys, hdf5, ... See >> spyking-circus help -i for more info
 stream_mode    = None                  # None by default. Can be multi-files, or anything depending to the file format
@@ -11,6 +21,9 @@ overwrite      = True                  # Filter or remove artefacts on site (if 
 parallel_hdf5  = True                  # Use the parallel HDF5 feature (if available)
 output_dir     =                       # By default, generated data are in the same folder as the data.
 
+#=========================================================================
+# detection 
+#=========================================================================
 [detection]
 radius         = auto       # Radius [in um] (if auto, read from the prb file)
 N_t            = 3          # Width of the templates [in ms]
@@ -19,12 +32,18 @@ peaks          = negative   # Can be negative (default), positive or both
 alignment      = True       # Realign the waveforms by oversampling
 dead_channels  =            # If not empty or specified in the probe, a dictionary {channel_group : [list_of_valid_ids]}
 
+#=========================================================================
+# filtering 
+#=========================================================================
 [filtering]
 cut_off        = 300, auto  # Min and Max (auto=nyquist) cut off frequencies for the band pass butterworth filter [Hz]
 filter         = True       # If True, then a low-pass filtering is performed
 remove_median  = False      # If True, median over all channels is substracted to each channels (movement artifacts)
 common_ground  =            # If you want to use a particular channel as a reference ground: should be a channel number
 
+#=========================================================================
+# triggers 
+#=========================================================================
 [triggers]
 trig_file      =            # External stimuli to be considered as putative artefacts [in trig units] (see documentation)
 trig_windows   =            # The time windows of those external stimuli [in trig units]
@@ -35,6 +54,9 @@ dead_unit      = ms         # The unit in which times for dead regions are expre
 ignore_times   = False      # If True, any spike in the dead regions will be ignored by the analysis
 make_plots     =            # Generate sanity plots of the averaged artefacts [Nothing or None if no plots]
 
+#=========================================================================
+# whitening 
+#=========================================================================
 [whitening]
 chunk_size     = 30         # Size of the data chunks [in s]
 safety_time    = auto       # Temporal zone around which templates are isolated [in ms, or auto]
@@ -43,6 +65,9 @@ max_elts       = 1000       # Max number of events per electrode (should be comp
 nb_elts        = 0.8        # Fraction of max_elts that should be obtained per electrode [0-1]
 output_dim     = 5          # Can be in percent of variance explain, or num of dimensions for PCA on waveforms
 
+#=========================================================================
+# clustering 
+#=========================================================================
 [clustering]
 extraction     = median-raw # Can be either median-raw (default), median-pca, mean-pca, mean-raw
 sub_dim        = 10         # Number of dimensions to keep for local PCA per electrode
@@ -63,6 +88,9 @@ remove_mixture = True       # At the end of the clustering, we remove mixtures o
 cc_mixtures    = 0.75       # If CC between a sum of two templates and a template is higher, it is removed
 make_plots     =            # Generate sanity plots of the clustering [Nothing or None if no plots]
 
+#=========================================================================
+# fitting 
+#=========================================================================
 [fitting]
 chunk_size     = 1          # Size of chunks used during fitting [in second]
 amp_limits     = (0.3, 5)   # Amplitudes for the templates during spike detection [if not auto]
@@ -70,6 +98,9 @@ amp_auto       = True       # True if amplitudes are adjusted automatically for 
 max_chunk      = inf        # Fit only up to max_chunk
 collect_all    = False      # If True, one garbage template per electrode is created, to store unfitted spikes
 
+#=========================================================================
+# merging 
+#=========================================================================
 [merging]
 cc_overlap     = 0.85       # Only templates with CC higher than cc_overlap may be merged
 cc_bin         = 2          # Bin size for computing CC [in ms]
@@ -78,6 +109,9 @@ default_lag    = 5          # Default length of the period to compute dip in the
 auto_mode      = 0.75       # Between 0 (aggressive) and 1 (no merging). If empty, GUI is launched
 remove_noise   = False      # If True, meta merging will remove obvious noise templates (weak amplitudes)
 
+#=========================================================================
+# converting 
+#=========================================================================
 [converting]
 erase_all      = True       # If False, a prompt will ask you to export if export has already been done
 export_pcs     = prompt     # Can be prompt [default] or in none, all, some
@@ -85,6 +119,9 @@ export_all     = False      # If True, unfitted spikes will be exported as the l
 sparse_export  = True       # For recent versions of phy, and large number of templates/channels
 prelabelling   = False      # If True, putative labels (good, noise, best, mua) are pre-assigned to neurons
 
+#=========================================================================
+# validating 
+#=========================================================================
 [validating]
 nearest_elec   = auto       # Validation channel (e.g. electrode closest to the ground truth cell)
 max_iter       = 200        # Maximum number of iterations of the stochastic gradient descent (SGD)
@@ -99,6 +136,9 @@ juxta_spikes   =            # If none, spikes are automatically detected based o
 filter         = True       # If the juxta channel need to be filtered or not
 make_plots     = png        # Generate sanity plots of the validation [Nothing or None if no plots]
 
+#=========================================================================
+# extracting 
+#=========================================================================
 [extracting]
 safety_time    = 1          # Temporal zone around which spikes are isolated [in ms]
 max_elts       = 1000       # Max number of collected events per templates
@@ -106,6 +146,9 @@ output_dim     = 5          # Percentage of variance explained while performing 
 cc_merge       = 0.975      # If CC between two templates is higher, they are merged
 noise_thr      = 0.8        # Minimal amplitudes are such than amp*min(templates) < noise_thr*threshold
 
+#=========================================================================
+# noedits will be writing by spyking-circus 
+#=========================================================================
 [noedits]
 filter_done    = False      # Will become True automatically after filtering
 artefacts_done = False      # Will become True automatically after removing artefacts

--- a/circus/filtering.py
+++ b/circus/filtering.py
@@ -1,3 +1,11 @@
+"""
+filtering.py
+
+author: Pierre Yeger
+e-mail: pierre.yger <at> inserm.fr
+
+Executes filtering and trigger sections on the data. 
+"""
 from scipy import signal
 from .shared import plot
 from .shared.utils import *
@@ -6,6 +14,26 @@ from circus.shared.messages import print_and_log, init_logging
 from circus.shared.files import get_artefact
 
 def check_if_done(params, flag, logger):
+    """
+    Read filter_done in [noedits] section of the param file
+
+    Parameters
+    ----------
+    params : CircusParser object 
+        the parser objects with filtering options from param file.
+
+    flag : str
+        'filter_done', 'artefacts_done', 'median_done' or 'ground_done'
+    
+    logger : logging object
+        log message id
+
+    Return
+    ------
+    bool
+        True if data has been filtered, false if data was not
+        filtered, or started if filtering started.
+    """
         value = params.get('noedits', flag).lower().strip()
         if value == 'false':
             return False
@@ -45,10 +73,26 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
 
 
     def filter_file(data_file_in, data_file_out, do_filtering, do_remove_median, do_remove_ground):
+        """
+        Performs a high-pass and low-pass Butterworth filter on the data file.
+
+        Parameters
+        ----------
+        
+        data_file_in : 
+
+        data_file_out : 
+
+        do_filtering : bool
+
+        do_remove_median : bool
+ 
+        do_remove_median : bool
+        """
 
         try:
             cut_off    = params.getfloat('filtering', 'cut_off')
-            cut_off    = [cut_off, 0.95*(params.rate/2.)]
+            cut_off    = [cut_off, 0.95*(params.rate/2.)] # Nyquist 
         except Exception:
             cut_off        = params.get('filtering', 'cut_off')
             cut_off        = cut_off.split(',')
@@ -137,6 +181,18 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
 
 
     def compute_artefacts(data_file):
+        """
+        Compute artefact locations based on the [triggers] section of the params file.
+
+        Parameters
+        ----------
+        data_file :
+
+        Return
+        ------
+        dict
+            A dictionary with the location of the artefacts
+        """
 
         chunk_size     = params.getint('data', 'chunk_size')
         trig_in_ms     = params.getboolean('triggers', 'trig_in_ms')
@@ -210,6 +266,17 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
 
 
     def remove_artefacts(data_file, art_dict):
+        """
+        Remove artefact times based on the [triggers] section of the params file.
+
+        Parameters
+        ----------
+
+        data_file :
+
+        art_dict : dict
+            a dictionary with the artefact times.
+        """
 
         chunk_size     = params.getint('data', 'chunk_size')
         trig_in_ms     = params.getboolean('triggers', 'trig_in_ms')

--- a/circus/filtering.py
+++ b/circus/filtering.py
@@ -34,23 +34,24 @@ def check_if_done(params, flag, logger):
         True if data has been filtered, false if data was not
         filtered, or started if filtering started.
     """
-        value = params.get('noedits', flag).lower().strip()
-        if value == 'false':
-            return False
-        elif value == 'true':
-            return True
-        elif value == 'started':
-            common_sentence = 'Data are likely to be corrupted, please recopy raw data'
-            particular_sentence = 'And set the flag %s in the [noedits] section to False' %flag
-            if comm.rank == 0:
-                if flag == 'filter_done':
-                    msg = ['Code was interrupted while filtering', common_sentence, particular_sentence]
-                elif flag == 'artefacts_done':
-                    msg = ['Code was interrupted while removing artefacts', common_sentence, particular_sentence]
-                elif flag == 'median_done':
-                    msg = ['Code was interrupted while removing median', common_sentence, particular_sentence]
-                elif flag == 'ground_done':
-                    msg = ['Code was interrupted while removing ground', common_sentence, particular_sentence]
+
+    value = params.get('noedits', flag).lower().strip()
+    if value == 'false':
+        return False
+    elif value == 'true':
+        return True
+    elif value == 'started':
+        common_sentence = 'Data are likely to be corrupted, please recopy raw data'
+        particular_sentence = 'And set the flag %s in the [noedits] section to False' %flag
+        if comm.rank == 0:
+            if flag == 'filter_done':
+                msg = ['Code was interrupted while filtering', common_sentence, particular_sentence]
+            elif flag == 'artefacts_done':
+                msg = ['Code was interrupted while removing artefacts', common_sentence, particular_sentence]
+            elif flag == 'median_done':
+                msg = ['Code was interrupted while removing median', common_sentence, particular_sentence]
+            elif flag == 'ground_done':
+                msg = ['Code was interrupted while removing ground', common_sentence, particular_sentence]
                 print_and_log(msg, 'error', logger)
             sys.exit(0)
 

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -791,7 +791,7 @@ def detect_peaks(x, mph=None, mpd=1, threshold=0, edge='rising', kpsh=False, val
     if show:
         if valley:
             x = -x
-        pylab.plot(ind, x[ind], 'ro')
+        pylab.plot(ind, x[ind], 'ro', fillstyle = 'none')
         pylab.plot(x, 'k')
 
     return ind

--- a/circus/shared/parser.py
+++ b/circus/shared/parser.py
@@ -115,7 +115,7 @@ class CircusParser(object):
                           ['clustering', 'nb_repeats', 'int', '3'],
                           ['clustering', 'make_plots', 'string', 'png'],
                           ['clustering', 'test_clusters', 'bool', 'False'],
-                          ['clustering', 'sim_same_elec', 'floaruntimepatht', '3'],
+                          ['clustering', 'sim_same_elec', 'float', '3'],
                           ['clustering', 'smart_search', 'bool', 'True'],
                           ['clustering', 'safety_space', 'bool', 'True'],
                           ['clustering', 'compress', 'bool', 'True'],

--- a/circus/shared/parser.py
+++ b/circus/shared/parser.py
@@ -1,3 +1,11 @@
+"""
+parser.py
+
+author: Pierre Yeger 
+mail: pierre.yger <at> inserm.fr
+
+Contains the class to read *param files
+"""
 import ConfigParser as configparser
 from messages import print_and_log
 from circus.shared.probes import read_probe, parse_dead_channels
@@ -9,6 +17,60 @@ import os, sys, copy, numpy, logging
 logger = logging.getLogger(__name__)
 
 class CircusParser(object):
+    """
+    Circus class to read *param files.
+
+    Attributes
+    ----------
+    do_folders : bool
+        if a folder must be created upon reading
+
+    file_format : str
+        file format of the recording (see with spyking-circus help -i)
+
+    file_name : str
+        path of recording file (e.g., '/analysis/continuous.dat')
+
+    file_params : str
+        path of the parameters file (e.g., '/analysis/continuous.params')
+ 
+    logfile : str
+        path of the spyking-circus log file created after execution
+
+    nb_channels : int 
+        number of recording channels described in the probe file.
+
+    parser : configparser
+
+    probe : dict
+        the content of the probe file.
+    
+    Methods
+    -------
+
+    get(section, data)
+        gets the data variable in the section of the params file.
+
+    getboolean(section, data)
+        gets the data variable in the section of the params file as bool.
+
+    getfloat(section, data)
+        gets the data variable in the section of the params file as float.
+
+    getint(section, data)
+        gets the data variable in the section of the params file as integer.
+
+    set(section, data)
+        sets a data variable in the section of the params file.
+
+    get_data_file(is_empty=False, params=None, source=False, has_been_created=True)
+        creates a dictionary form the datafile section in the param file.
+
+    write(section, flag, value, preview_)
+        writes the value in the variable data of a section of a param file.
+    
+    
+    """
 
     __all_sections__ = ['data', 'whitening', 'extracting', 'clustering',
                        'fitting', 'filtering', 'merging', 'noedits', 'triggers',
@@ -53,7 +115,7 @@ class CircusParser(object):
                           ['clustering', 'nb_repeats', 'int', '3'],
                           ['clustering', 'make_plots', 'string', 'png'],
                           ['clustering', 'test_clusters', 'bool', 'False'],
-                          ['clustering', 'sim_same_elec', 'float', '3'],
+                          ['clustering', 'sim_same_elec', 'floaruntimepatht', '3'],
                           ['clustering', 'smart_search', 'bool', 'True'],
                           ['clustering', 'safety_space', 'bool', 'True'],
                           ['clustering', 'compress', 'bool', 'True'],
@@ -112,7 +174,22 @@ class CircusParser(object):
                         ['clustering', 'dip_threshold', 'float', '0.5']]
 
     def __init__(self, file_name, create_folders=True, **kwargs):
+        """
+        Parameters:
+        ----------
+        file_name : string
+            a path containing the *params file.
 
+        create_folders : bool
+            if a folder will be created. If true, output_dir in the data section
+        of the param file will be created.
+
+        
+        Returns:
+        --------
+        a CircusParser object. 
+
+        """ 
         self.file_name    = os.path.abspath(file_name)
         f_next, extension = os.path.splitext(self.file_name)
         file_path         = os.path.dirname(self.file_name)
@@ -443,21 +520,105 @@ class CircusParser(object):
                 print_and_log(["Hanning filtering is activated"], 'debug', logger)
 
     def get(self, section, data):
+        """
+        Gets the value of the  variable data in a section as a string.
+
+        Parameters
+        ----------
+        section :  str
+            the section in *params to be read (e.g., 'detection')
+        
+        data : str
+            the variable data to be read (e.g., 'oversampling_factor')
+
+        Returns
+        -------
+        str 
+            The value of the variable data.    
+        
+        """
       	return self.parser.get(section, data)
 
     def getboolean(self, section, data):
+        """
+        Gets the boolean variable from the variable data in a section
+
+        Parameters
+        ----------
+        section :  str
+            the section in *params to be read (e.g., 'filtering')
+        
+        data : str
+            the variable data to be read (e.g., 'remove_median')
+
+        Returns
+        -------
+        bool
+            if the variable data is applied or not.    
+        
+        """
       	return self.parser.getboolean(section, data)
 
     def getfloat(self, section, data):
+        """
+        Gets the value of the  variable data in a section
+
+        Parameters
+        ----------
+        section :  str
+            the section in *params to be read (e.g., 'clustering')
+        
+        data : str
+            the variable data to be read (e.g., 'nb_elts')
+
+        Returns
+        -------
+        float 
+            The value of the variable data.    
+        
+        """
       	return self.parser.getfloat(section, data)
 
     def getint(self, section, data):
+        """
+        Gets the value of the  variable data in a section
+
+        Parameters
+        ----------
+        section :  str
+            the section in *params to be read (e.g., 'detection')
+        
+        data : str
+            the variable data to be read (e.g., 'oversampling_factor')
+
+        Returns
+        -------
+        int 
+            The value of the variable data.    
+        
+        """
       	return self.parser.getint(section, data)
 
     def set(self, section, data, value):
+        """
+        Assigns a value to a variable data in a section
+
+        Parameters
+        ----------
+        section :  str
+            the section in *params to be read (e.g., 'detection')
+        
+        data : str
+            the variable data to be read (e.g., 'oversampling_factor')
+
+        """
+
         self.parser.set(section, data, value)
 
     def _update_rate_values(self):
+        """
+        Updates temporal values depending on the sampling rate of the recordings.
+        """
 
         if self._N_t is None:
 
@@ -472,7 +633,7 @@ class CircusParser(object):
                     print_and_log(['N_t must now be defined in the [detection] section'], 'error', logger)
                 sys.exit(0)
 
-            self._N_t = int(self.rate*self._N_t*1e-3)
+            self._N_t = int(self.rate*self._N_t*1e-3) 
 
             jitter_range = self.getfloat('detection', 'jitter_range')
             self.set('detection', 'jitter_range', str(int(self.rate*jitter_range*1e-3)))
@@ -509,6 +670,27 @@ class CircusParser(object):
 
 
     def _create_data_file(self, data_file, is_empty, params, stream_mode):
+        """
+        Creates a data file with parameters from the param file.
+
+        Parameters
+        ----------
+
+        data_file : str 
+            the path for the datafile
+        
+        is_empty : bool
+
+        params :  dict
+
+        stream_mode : str
+            multi-files, multi-folders or single-file.
+
+        Returns
+        -------
+        dict
+            a supported data file with the parameters from the param file.
+        """
         file_format       = params.pop('file_format').lower()
         if comm.rank == 0:
             print_and_log(['Trying to read file %s as %s' %(data_file, file_format)], 'debug', logger)
@@ -530,6 +712,26 @@ class CircusParser(object):
 
 
     def get_data_file(self, is_empty=False, params=None, source=False, has_been_created=True):
+        """
+        Gets the datafile as described in the param files.
+
+        Parameters
+        ----------
+        is_empty : bool
+
+        params : dict
+
+        source : bool
+
+        has_been_created : bool
+            if the data file was 
+
+        Returns
+        -------
+        dict   
+            A dictionary with the parameters of created data file.
+
+        """
 
         if params is None:
             params = {}
@@ -588,6 +790,22 @@ class CircusParser(object):
 
 
     def write(self, section, flag, value, preview_path=False):
+        """
+        Writes the section of the param file with 
+
+        Parameters
+        ----------
+        section : str
+            a section in the param file
+
+        flag : str
+
+            a variable of a section in the param file
+
+        value : str
+
+            the value of the variable data in a section of param file.
+        """
         if comm.rank == 0:
             print_and_log(['Writing value %s for %s:%s' %(value, section, flag)], 'debug', logger)
         self.parser.set(section, flag, value)

--- a/circus/thresholding.py
+++ b/circus/thresholding.py
@@ -148,7 +148,7 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
         else:
             for i in xrange(N_e):
                 if sign_peaks == 'negative':
-                    peaktimes = algo.detect_peaks(local_chunk[:, i], thresholds[i], valley=True, mpd=dist_peaks)
+                    peaktimes = algo.detect_peaks(x = local_chunk[:, i], threshold = thresholds[i], valley=1, mpd=dist_peaks)
                 elif sign_peaks == 'positive':
                     peaktimes = algo.detect_peaks(local_chunk[:, i], thresholds[i], valley=False, mpd=dist_peaks)
                 elif sign_peaks == 'both':

--- a/docs_sphinx/code/merging.rst
+++ b/docs_sphinx/code/merging.rst
@@ -30,7 +30,7 @@ An iterative procedure with a dedicated GUI
 
 We design a Python GUI to quickly visualize all those values and allow human to quickly performs all merges that need to be done. To launch it, with *N* processors, you need to do::
 
-    >> spykig-circus mydata.extension -m merging -c N
+    >> spyking-circus mydata.extension -m merging -c N
 
 The GUI is still an ongoing work, so any feedbacks are welcome, but the idea is to show, in a single plot, all the putative pairs of cells that have to be merged. As can be seen in the top left panel, every point is a pair of neuron, and x-axis in the upper left panel shows the template similarity (between ``cc_merge`` and 1), while y-axis show the normalized difference between the control CC and the normal CC (see above). In the bottom left plot, this is the same measure on the y-axis, while the x-axis only shows the CC of the Reverse Cross-Correlogram. **Any pairs along the diagonal are likely to be merged**
 

--- a/docs_sphinx/code/parameters.rst
+++ b/docs_sphinx/code/parameters.rst
@@ -59,9 +59,9 @@ To know more about the host file, see the MPI section :doc:`documentation on MPI
 
 The code can accept a text file with several commands that will be executed one after the other, in a batch mode. This is interesting for processing several datasets in a row. An example of such a text file ``commands.txt`` would simply be::
     
-    path/mydata1.extention -c 10
-    path/mydata2.extention -c 10 -m fitting
-    path/mydata3.extention -c 10 -m clustering,fitting,converting
+    path/mydata1.extension -c 10
+    path/mydata2.extension -c 10 -m fitting
+    path/mydata3.extension -c 10 -m clustering,fitting,converting
 
 Then simply launch the code by doing::
 

--- a/docs_sphinx/code/probe.rst
+++ b/docs_sphinx/code/probe.rst
@@ -93,7 +93,7 @@ How do deal with several shanks ?
 
 There are two ways to simply handle several shanks:
 
-* in the ``.prb`` file, you can create a single large channel group, where all the shanks are far enough (for example in the x direction), such that templates will not interact (based on the physical ``radius``). If your radius is 200umm, for example, if you set x to 0 for the first shank, 300 for the second one, and so on, templates will be confined per shank.
+* in the ``.prb`` file, you can create a single large channel group, where all the shanks are far enough (for example in the x direction), such that templates will not interact (based on the physical ``radius``). If your radius is 200 um, for example, if you set x to 0 for the first shank, 300 for the second one, and so on, templates will be confined per shank.
 
 * in the ``.prb`` file, you can also have several channel groups (see for example adrien.prb in the probes folder). What is done by the code, then, is that during internal computations templates are confined to each channel groups. However, for graphical purpose, when you'll use the GUI, the global x/y coordinates across all shanks are used. Therefore, if you do not want to have them plotted on top of each other, you still need to add a x/y padding for all of them.
 


### PR DESCRIPTION
To assist the code documentation:

1. corrected typos in the documentation
2. docstring documentation for methods and attributes of CircusParser class
3. block separation of sections of param file
4. added some PEP8 standards to document functions and methods
5. string casting in parser setter to avoid redundant argument casting, like 'self.set('detection', 'N_t', str(self._N_t))'