### PR TITLE
A suggestion to permit comments in dead_files

### DIFF
--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -162,9 +162,23 @@ def get_stas(params, times_i, labels_i, src, neighs, nodes=None, mean_mode=False
 
 
 def get_dead_times(params):
+    """
+    Read the sampling points to be excluced from the data file from 
+    'dead_file' in [triggers] section of the params file. If 'dead_unit'
+    is 'ms', it will transform sampling points in ms.
+
+    Parameters
+    ----------
+    params -- the parameter file.
+
+    Returns
+    -------
+    A 2D NumPy array containing the start and stop sampling points 
+    (or times) to be excluded from the data. 
+    """
 
     def _get_dead_times(params):
-        dead_times = numpy.loadtxt(params.get('triggers', 'dead_file'))
+        dead_times = numpy.loadtxt(fname = params.get('triggers', 'dead_file'), comments =['#','//'])
         data_file  = params.data_file
         if len(dead_times.shape) == 1:
             dead_times = dead_times.reshape(1, 2)

--- a/docs_sphinx/code/artefacts.rst
+++ b/docs_sphinx/code/artefacts.rst
@@ -14,8 +14,12 @@ Setting dead periods
 
 In a text file, you must specify all the portions [t_start, t_stop] that you want to exclude from analysis. The times can be given in ms or in timesteps, and this can be changed with the ``dead_unit`` parameter. By default, they are assumed to be in ms. Assuming we want to exclude the first 500ms of every second, such a text file will look like::
 	
+    // myartefact.dead
+    // Exclude 500 ms every 1000 ms from t=0 until t=10 seg
+    // times are given in 'ms' (set dead_unit = 'ms' in [triggers]
+    // columns: t_start t_stop
 	0 500 
-	1000 1500
+	1000 1500 # this is a comment
 	2000 2500
 	...
 	10000 10500


### PR DESCRIPTION
- - adapt np.loadtxt to accept comments from dead_file
- - document the possibility of using comments in the ascii file for triggers.