### PR TITLE
Adding Cambridge Neurotech probe

### DIFF
--- a/probes/ASSY-77-P.prb
+++ b/probes/ASSY-77-P.prb
@@ -1,0 +1,116 @@
+"""
+ASSY-77-P.prb
+
+Author: Jose Guzman, jose.guzman<at>guzman-lab.com
+Created: Mon May  6 12:22:42 CEST 2019
+
+The probe file for the silicon probe model ASSY-77 from the P-series
+from Cambridge NeuroTech (info<at>cambridgeneurotech.com)
+The P1 has 6 mm long shank, the P2 model 9 mm.
+The probe consists of FOUR 250 um-separated shanks of 16 recording sites. 
+The 16 recording sites cover a distance of 200 um and are spaced every 
+25 um. The total number of electrodes is 64. The electrode size is 
+11x15 um and the shank thickness 15 um.
+
+The file creates a main python dictionary called channel_groups. The 
+dictionary contains four dictionaries called '0', '1', '2' and '3'
+corresponding to the four schanks of the silicon probe (A,B,C and D). 
+Every shank contains another dictionary with "channels", "graph" and 
+"geometry" having the channel number.
+
+"""
+
+#=========================================================================
+# Skyking-circus parameters
+#=========================================================================
+total_nb_channels = 67 # number of recording sites (3 for TTL)
+radius = 200 # spatial extent (in um)
+channel_groups = {1: dict(), 2: dict(), 3: dict(), 4: dict()} # four shanks
+
+#=========================================================================
+# "channels" defined from channel mapping
+#=========================================================================
+shankA = range(16)
+shankB = range(16,32)
+shankC = range(32,48)
+shankD = range(48,64)
+
+#=========================================================================
+# Assign "channels" from channel maps 
+#=========================================================================
+channel_groups[1]["channels"] = shankA
+channel_groups[2]["channels"] = shankB
+channel_groups[3]["channels"] = shankC
+channel_groups[4]["channels"] = shankD
+
+#=========================================================================
+# Assign "geometry" for calculated locations 
+#=========================================================================
+def get_locations(xloc = 0, xstep = 22.5, ystep = 25):
+    """
+    generate a list of  16 (x,y) coordinates (in um) for a shank
+
+    Arguments:
+    ----------
+    initloc (int): the starting xlocation of the first
+        recording site up in the probe. After that, locations move
+        to the left one step, and down step. Zero by default.
+    ystep (float): horizontal distance between electrodes. Default 25 um.
+    xstep (float): vertical distance between electrodes. Default 22.5 um.
+
+    Return:
+    -------
+    A list with (x,y) coordinates for 16 electrodes in the shank
+
+    Example:
+    --------
+    get_geometry(xloc = 250, step = 25) # return coord shank B
+    """
+
+    mycoor = list()
+    for yloc in range(0, -8*ystep, -ystep):
+        right = (xloc, yloc) # rigth electrode
+        left  = (xloc-xstep, yloc-ystep/2.0 ) # left-down electrode
+
+        mycoor.append(right)
+        mycoor.append(left)
+    
+    return mycoor
+
+# create dictionaries 'zipping' shanks and locations
+channel_groups[1]["geometry"] = dict( zip(shankA, get_locations(xloc=0)))
+channel_groups[2]["geometry"] = dict( zip(shankB, get_locations(xloc=250)))
+channel_groups[3]["geometry"] = dict( zip(shankC, get_locations(xloc=500)))
+channel_groups[4]["geometry"] = dict( zip(shankD, get_locations(xloc=750)))
+    
+#=========================================================================
+# Assign "graph" of adjancenct nodes to have phy compatibility
+#=========================================================================
+def get_graph(shank):
+    """
+    generate adjacency graph. It adds the two closest electrodes for 
+    for every electrode in the shank.
+    
+    Arguments:
+    ---------
+    A shank with the list of electrodes
+
+    Returns:
+    --------
+    A list tuples with the two closest electrodes
+    It is 2x the size of the shank list.
+    """
+    mygraph = list()
+    i = 0;
+    while i<len(shank)-2:
+        mygraph.append( (shank[i],shank[i+1]) ) 
+        mygraph.append( (shank[i],shank[i+2]) )
+        i +=1
+
+    return mygraph
+    
+channel_groups[1]["graph"] = get_graph(shankA)
+channel_groups[2]["graph"] = get_graph(shankB)
+channel_groups[3]["graph"] = get_graph(shankC)
+channel_groups[4]["graph"] = get_graph(shankD)
+    


### PR DESCRIPTION
Probe specification is a tedious process for the user. Having as many probes as possible will permit to focus on the software parameters and less on the probe geometry or electrode locations.