### PR TITLE
Basic support for 3D probes

### DIFF
--- a/changelog
+++ b/changelog
@@ -15,6 +15,7 @@ Release 0.8.4
 * sparse export for phy is now the default
 * comments can now be added in the trigger/dead times files
 * 4096 channels can now run on a single machine, with low memory consumption
+* basic support for 3d probes, without any visualization
 
 =============
 Release 0.8.3

--- a/circus/shared/probes.py
+++ b/circus/shared/probes.py
@@ -60,10 +60,25 @@ def get_nodes_and_edges(parser, validating=False):
 
     def get_edges(i, channel_groups):
         edges = []
-        pos_x, pos_y = channel_groups['geometry'][i]
+        position = channel_groups['geometry'][i]
+        if len(position) == 2:
+            pos_x, pos_y, pos_z = position[0], position[1], 0
+        elif len(position) == 1:
+            pos_x, pos_y, pos_z = position[0], 0, 0
+        elif len(position) == 3:
+            pos_x, pos_y, pos_z = position[0], position[1], position[2]
+
         for c2 in channel_groups['channels']:
-            pos_x2, pos_y2 = channel_groups['geometry'][c2]
-            if (((pos_x - pos_x2)**2 + (pos_y - pos_y2)**2) <= radius**2):
+
+            position = channel_groups['geometry'][c2]
+            if len(position) == 2:
+                pos_x2, pos_y2, pos_z2 = position[0], position[1], 0
+            elif len(position) == 1:
+                pos_x2, pos_y2, pos_z2 = position[0], 0, 0
+            elif len(position) == 3:
+                pos_x2, pos_y2, pos_z2 = position[0], position[1], position[2]
+
+            if (((pos_x - pos_x2)**2 + (pos_y - pos_y2)**2 + (pos_z - pos_z2)**2) <= radius**2):
                 edges += [c2]
         return edges
 


### PR DESCRIPTION
With such a PR, users can provide 1D, 2D or 3D coordinates for the channels in the prb file. Note, however, that the visualization GUI will not work with 3D probes