### PR TITLE
Add support for MPI_VENDOR[0] == 'Intel MPI'

### DIFF
--- a/circus/shared/mpi.py
+++ b/circus/shared/mpi.py
@@ -129,6 +129,10 @@ def gather_mpi_arguments(hostfile, params):
         mpi_args = ['mpiexec']
         if os.path.exists(hostfile):
             mpi_args += ['-f', hostfile]
+    elif MPI_VENDOR[0] == 'Intel MPI':
+        mpi_args = ['mpiexec']
+        if os.path.exists(hostfile):
+            mpi_args += ['-hosts', hostfile]
     else:
         print_and_log([
                         '%s may not be yet properly implemented: contact developpers' %


### PR DESCRIPTION
Following the install instructions on windows, I ended up with `MPI_VENDOR[0] == 'Intel MPI'`. This wasn't in the list of known vendor strings, resulting in the attempted use of incorrect `mpirun` instead of the correct `mpiexec`, with the following printouts:

```
----------------------------  Error  -----------------------------
| Intel MPI may not be yet properly implemented: contact developpers
------------------------------------------------------------------
-------------------------  Informations  -------------------------
| No parallel writes for nwb: only 1 node used for filtering
------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Chad\.conda\envs\circus\Scripts\spyking-circus-script.py", line 11, in <module>
    load_entry_point('spyking-circus==0.9.7', 'console_scripts', 'spyking-circus')()
  File "C:\Users\Chad\.conda\envs\circus\lib\site-packages\circus\scripts\launch.py", line 428, in main
    subprocess.check_call(mpi_args)
  File "C:\Users\Chad\.conda\envs\circus\lib\subprocess.py", line 306, in check_call
    retcode = call(*popenargs, **kwargs)
  File "C:\Users\Chad\.conda\envs\circus\lib\subprocess.py", line 287, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\Users\Chad\.conda\envs\circus\lib\subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "C:\Users\Chad\.conda\envs\circus\lib\subprocess.py", line 1017, in _execute_child
    startupinfo)
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

I don't really know what the hostfile does so I can't be sure that the `-hosts` argument to Intel MPI's `mpiexec` is the right place for it. From the `mpiexec` docstring:

> Global environment options:
> -hosts {host list}               comma separated host list
> -hosts-group {groups of hosts}   allows to set node ranges (like in Slurm* Workload Manager)

Maybe the hostfile needs to be read in first? I don't know how to test this.