### PR TITLE
Refine

### DIFF
--- a/changelog
+++ b/changelog
@@ -5,6 +5,7 @@ Release 0.9.8
 * fix a bug while filtering HDF5 file with overwrite set to False
 * fix a bug for windows and Intel MPI
 * reducing the memory footprint while optimizing amplitudes for large number of templates
+* changing the way of saving overlaps, making use of internal symmetry. Lot of memory saved
 
 =============
 Release 0.9.7

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -785,11 +785,11 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             local_data = over_data[xmin:xmax]
 
             xmin, xmax = bounds_2[2*count:2*(count+1)]
-            nslice = mask_duration[over_sorted[xmin:xmax]]
+            nslice = over_sorted[xmin:xmax][mask_duration[over_sorted[xmin:xmax]]]
 
-            local_x = numpy.concatenate((local_x, over_x[xmin:xmax][nslice] // nb_temp))
-            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[xmin:xmax][nslice]))
-            local_data = numpy.concatenate((local_data, over_data[xmin:xmax][nslice]))
+            local_x = numpy.concatenate((local_x, over_x[nslice] // nb_temp))
+            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
+            local_data = numpy.concatenate((local_data, over_data[nslice]))
 
             data = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(nb_temp, over_shape[1]), dtype=numpy.float32)
             distances[count, :] = data.max(1).toarray().flatten()

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -770,11 +770,12 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             res2 += [i, i+1]
 
         bounds = numpy.searchsorted(over_x, res, 'left')
+        bounds_2 = numpy.searchsorted(sub_over[over_sorted], res2, 'left')
+
         duration = over_shape[1] // 2
         mask_duration = (over_y < duration)
 
-        indices = numpy.argsort(sub_over)
-        bounds_2 = numpy.searchsorted(sub_over[indices], res2, 'left')
+        import gc
 
         for count, i in enumerate(to_explore):
 
@@ -784,15 +785,16 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             local_data = over_data[xmin:xmax]
 
             xmin, xmax = bounds_2[2*count:2*(count+1)]
-            nslice = over_sorted[numpy.where(mask_duration[over_sorted[xmin:xmax]])]
+            nslice = mask_duration[over_sorted[xmin:xmax]]
 
-            local_x = numpy.concatenate((local_x, over_x[nslice] // nb_temp))
-            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
-            local_data = numpy.concatenate((local_data, over_data[nslice]))
+            local_x = numpy.concatenate((local_x, over_x[xmin:xmax][nslice] // nb_temp))
+            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[xmin:xmax][nslice]))
+            local_data = numpy.concatenate((local_data, over_data[xmin:xmax][nslice]))
 
             data = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(nb_temp, over_shape[1]), dtype=numpy.float32)
             distances[count, :] = data.max(1).toarray().flatten()
-            del local_x, local_y, local_data, data
+            del local_x, local_y, local_data, data, nslice
+            gc.collect()
 
         distances /= norm
 

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -784,7 +784,7 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             local_data = numpy.concatenate((local_data, over_data[nslice]))
 
             data = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(nb_temp, over_shape[1]), dtype=numpy.float32)
-            distances[count, (i+1):] = data.max(1).toarray().flatten()[(i+1):]
+            distances[count, :] = data.max(1).toarray().flatten()
             del local_x, local_y, local_data, data
 
         distances /= norm
@@ -798,6 +798,9 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             indices = numpy.argsort(indices)
 
             distances = distances[indices, :]
+            line = numpy.arange(nb_temp)
+            distances[line, line] = 0
+
             #distances = numpy.maximum(distances, distances.T)
 
         comm.Barrier()

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -785,8 +785,8 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
 
             xmin, xmax = bounds_2[2*count:2*(count+1)]
             nslice = over_sorted[numpy.where(mask_duration[over_sorted[xmin:xmax]])]
-            
-            local_x = numpy.concatenate((local_x, over_x[nslice] / nb_temp))
+
+            local_x = numpy.concatenate((local_x, over_x[nslice] // nb_temp))
             local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
             local_data = numpy.concatenate((local_data, over_data[nslice]))
 
@@ -829,7 +829,7 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
 
         comm.Barrier()
 
-        del result, over_x, over_y, over_data
+        del result, over_x, over_y, over_data, over_sorted, sub_over
 
         if comm.rank == 0:
             os.remove(filename)

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -751,11 +751,11 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
         SHARED_MEMORY = get_shared_memory_flag(params)
 
         if not SHARED_MEMORY:
-            over_x, over_y, over_data, over_shape = load_data(
+            over_x, over_y, over_data, sub_over, over_shape = load_data(
                 params, 'overlaps-raw', extension='-merging'
             )
         else:
-            over_x, over_y, over_data, over_shape, mpi_memory = load_data_memshared(
+            over_x, over_y, over_data, sub_over, over_shape, mpi_memory = load_data_memshared(
                 params, 'overlaps-raw', extension='-merging', use_gpu=use_gpu, nb_cpu=nb_cpu, nb_gpu=nb_gpu
             )
 
@@ -768,8 +768,8 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             res += [i * nb_temp, (i + 1) * nb_temp]
 
         bounds = numpy.searchsorted(over_x, res, 'left')
-        sub_over = numpy.mod(over_x, nb_temp)
         duration = over_shape[1] // 2
+        mask_duration = (over_y < duration)
 
         for count, i in enumerate(to_explore):
 
@@ -778,7 +778,7 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             local_y = over_y[xmin:xmax]
             local_data = over_data[xmin:xmax]
 
-            nslice = (sub_over == i) & (over_y < duration)
+            nslice = (sub_over == i) & mask_duration
             local_x = numpy.concatenate((local_x, over_x[nslice] / nb_temp))
             local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
             local_data = numpy.concatenate((local_data, over_data[nslice]))

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -769,6 +769,7 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
 
         bounds = numpy.searchsorted(over_x, res, 'left')
         sub_over = numpy.mod(over_x, nb_temp)
+        duration = over_shape[1] // 2
 
         for count, i in enumerate(to_explore):
 
@@ -777,8 +778,8 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             local_y = over_y[xmin:xmax]
             local_data = over_data[xmin:xmax]
 
-            nslice = (sub_over == i)
-            local_x = numpy.concatenate((local_x, sub_over[nslice]))
+            nslice = (sub_over == i) & (over_y < duration)
+            local_x = numpy.concatenate((local_x, over_x[nslice] / nb_temp))
             local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
             local_data = numpy.concatenate((local_data, over_data[nslice]))
 

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -951,7 +951,7 @@ def refine_amplitudes(params, nb_cpu, nb_gpu, use_gpu, normalization=True, debug
         snippets = get_stas(params, times_i, labels_i, ref_elec, neighs=sindices, nodes=nodes, pos=p)
 
         nb_snippets, nb_electrodes, nb_times_steps = snippets.shape
-        snippets = snippets.reshape(nb_snippets, nb_electrodes * nb_times_steps).T
+        snippets = numpy.ascontiguousarray(snippets.reshape(nb_snippets, nb_electrodes * nb_times_steps).T)
 
         for j in range(nb_temp):
             if mask_intersect[i, j]:
@@ -982,7 +982,7 @@ def refine_amplitudes(params, nb_cpu, nb_gpu, use_gpu, normalization=True, debug
         snippets = get_stas(params, times_i, labels_i, elec, neighs=sindices, nodes=nodes, auto_align=False)
 
         nb_snippets, nb_electrodes, nb_times_steps = snippets.shape
-        snippets = snippets.reshape(nb_snippets, nb_electrodes * nb_times_steps).T
+        snippets = numpy.ascontiguousarray(snippets.reshape(nb_snippets, nb_electrodes * nb_times_steps).T)
 
         for j in range(nb_temp):
             data = templates[j].dot(snippets)[0].astype(numpy.float32)

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -804,7 +804,7 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             indices = []
             for idx in range(comm.size):
                 indices += list(numpy.arange(idx, nb_temp, comm.size))
-            indices = numpy.argsort(indices)
+            indices = numpy.argsort(indices).astype(numpy.int32)
 
             distances = distances[indices, :]
             line = numpy.arange(nb_temp)
@@ -1032,7 +1032,7 @@ def refine_amplitudes(params, nb_cpu, nb_gpu, use_gpu, normalization=True, debug
             # We sort by x indices for faster retrieval later
             if comm.rank == 0:
                 if key == 'x':
-                    indices = numpy.argsort(data)
+                    indices = numpy.argsort(data).astype(numpy.int32)
                 
                 data = data[indices]
 
@@ -1242,7 +1242,7 @@ def refine_amplitudes(params, nb_cpu, nb_gpu, use_gpu, normalization=True, debug
         for idx in range(comm.size):
             indices += list(numpy.arange(idx, nb_temp, comm.size))
 
-        indices = numpy.argsort(indices)
+        indices = numpy.argsort(indices).astype(numpy.int32)
 
         if fine_amplitude:
             hfile['limits'][:] = bounds[indices]

--- a/circus/shared/algorithms.py
+++ b/circus/shared/algorithms.py
@@ -784,7 +784,7 @@ def merging_cc(params, nb_cpu, nb_gpu, use_gpu):
             local_data = numpy.concatenate((local_data, over_data[nslice]))
 
             data = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(nb_temp, over_shape[1]), dtype=numpy.float32)
-            distances[count, :] = data.max(1).toarray().flatten()
+            distances[count, (i+1):] = data.max(1).toarray().flatten()[(i+1):]
             del local_x, local_y, local_data, data
 
         distances /= norm

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -2062,6 +2062,7 @@ def get_overlaps(
 
         # Now we need to sync everything across nodes.
         maxlags = gather_array(maxlags, comm, 0, 1, 'int32', compress=blosc_compress)
+        line = numpy.arange(N_half)
 
         if comm.rank == 0:
             indices = []
@@ -2070,6 +2071,8 @@ def get_overlaps(
             indices = numpy.argsort(indices)
 
             maxlags = maxlags[indices, :]
+            maxlags[line, line] = 0
+
             #maxlags = numpy.maximum(maxlags, maxlags.T)
             #mask = numpy.tril(numpy.ones((N_half, N_half)), -1) > 0
             #maxlags[mask] *= -1
@@ -2086,6 +2089,7 @@ def get_overlaps(
             indices = numpy.argsort(indices)
 
             maxoverlaps = maxoverlaps[indices, :]
+            maxoverlaps[line, line] = 0
             #maxoverlaps = numpy.maximum(maxoverlaps, maxoverlaps.T)
         else:
             del maxoverlaps

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -476,7 +476,6 @@ def load_data_memshared(
             over_shape = c_overlap.get('over_shape')[:]
             N_over = numpy.int64(numpy.sqrt(over_shape[0]))
             S_over = over_shape[1]
-            duration = S_over // 2
             c_overs = {}
             nb_data = 0
 
@@ -484,7 +483,7 @@ def load_data_memshared(
                 over_x = c_overlap.get('over_x')[:]
                 over_y = c_overlap.get('over_y')[:]
                 over_data = c_overlap.get('over_data')[:]
-                nb_data = len(over_x) * (duration / (duration - 1))
+                nb_data = len(over_x) * 2 + N_over
 
             c_overlap.close()
 
@@ -512,6 +511,8 @@ def load_data_memshared(
             local_nb_data = 0
             local_nb_ptr = 0
 
+            duration = over_shape[1] // 2
+
             res = []
             for i in range(N_over):
                 res += [i * N_over, (i + 1) * N_over]
@@ -528,9 +529,9 @@ def load_data_memshared(
                     local_y = over_y[xmin:xmax]
                     local_data = over_data[xmin:xmax]
 
-                    nslice = sub_over == i
-                    local_x = numpy.concatenate((local_x, sub_over[nslice]))
-                    local_y = numpy.concatenate((local_y, (S_over - 1) - over_y[nslice]))
+                    nslice = (sub_over == i) & (over_y < duration)
+                    local_x = numpy.concatenate((local_x, over_x[nslice] / N_over))
+                    local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
                     local_data = numpy.concatenate((local_data, over_data[nslice]))
 
                     sparse_mat = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(N_over, over_shape[1]))
@@ -958,15 +959,33 @@ def load_data(params, data, extension=''):
             over_y = myfile.get('over_y')[:].ravel()
             over_data = myfile.get('over_data')[:].ravel()
             over_shape = myfile.get('over_shape')[:].ravel()
+            duration = over_shape[1] // 2
             myfile.close()
 
             c_overs = {}
             N_over = int(numpy.sqrt(over_shape[0]))
 
+            res = []
             for i in range(N_over):
-                idx = numpy.where((over_x >= i*N_over) & (over_x < ((i+1)*N_over)))[0]
-                local_x = over_x[idx] - i*N_over
-                c_overs[i] = scipy.sparse.csr_matrix((over_data[idx], (local_x, over_y[idx])), shape=(N_over, over_shape[1]))
+                res += [i * N_over, (i + 1) * N_over]
+
+            bounds = numpy.searchsorted(over_x, res, 'left')
+            sub_over = numpy.mod(over_x, N_over)
+
+            for count, i in enumerate(range(N_over)):
+
+                xmin, xmax = bounds[2*count:2*(count+1)]
+                local_x = over_x[xmin:xmax] - (i * N_over)
+                local_y = over_y[xmin:xmax]
+                local_data = over_data[xmin:xmax]
+
+                nslice = (sub_over == i) & (over_y < duration)
+                
+                local_x = numpy.concatenate((local_x, over_x[nslice] / N_over))
+                local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
+                local_data = numpy.concatenate((local_data, over_data[nslice]))
+
+                c_overs[i] = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(N_over, over_shape[1]))
 
             del over_x, over_y, over_data, over_shape
 
@@ -2019,6 +2038,7 @@ def get_overlaps(
 
         bounds = numpy.searchsorted(over_x, res, 'left')
         sub_over = numpy.mod(over_x, N_tm)
+        duration = over_shape[1] // 2
 
         for count, i in enumerate(to_explore):
 
@@ -2028,10 +2048,9 @@ def get_overlaps(
             local_y = over_y[xmin:xmax]
             local_data = over_data[xmin:xmax]
 
-            nslice = (sub_over == i) & (over_x < (i * N_tm + N_half))
-
-            local_x = numpy.concatenate((local_x, sub_over[nslice]))
-            local_y = numpy.concatenate((local_y, (duration - 1) - over_y[nslice]))
+            nslice = (sub_over == i) & (over_x < (i * N_tm + N_half)) & (over_y < duration)
+            local_x = numpy.concatenate((local_x, over_x[nslice] / N_tm))
+            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
             local_data = numpy.concatenate((local_data, over_data[nslice]))
 
             data = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(N_half, over_shape[1]), dtype=numpy.float32)

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -537,11 +537,11 @@ def load_data_memshared(
                     local_data = over_data[xmin:xmax]
 
                     xmin, xmax = bounds_2[2*i:2*(i+1)]
-                    nslice = mask_duration[over_sorted[xmin:xmax]]
+                    nslice = over_sorted[xmin:xmax][mask_duration[over_sorted[xmin:xmax]]]
 
-                    local_x = numpy.concatenate((local_x, over_x[xmin:xmax][nslice] // N_over))
-                    local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[xmin:xmax][nslice]))
-                    local_data = numpy.concatenate((local_data, over_data[xmin:xmax][nslice]))
+                    local_x = numpy.concatenate((local_x, over_x[nslice] // N_over))
+                    local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
+                    local_data = numpy.concatenate((local_data, over_data[nslice]))
 
                     sparse_mat = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(N_over, over_shape[1]))
                     local_nb_data = len(sparse_mat.data)
@@ -1013,11 +1013,11 @@ def load_data(params, data, extension=''):
                 local_data = over_data[xmin:xmax]
 
                 xmin, xmax = bounds_2[2*i:2*(i+1)]
-                nslice = mask_duration[over_sorted[xmin:xmax]]
+                nslice = over_sorted[xmin:xmax][mask_duration[over_sorted[xmin:xmax]]]
 
-                local_x = numpy.concatenate((local_x, over_x[xmin:xmax][nslice] // N_over))
-                local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[xmin:xmax][nslice]))
-                local_data = numpy.concatenate((local_data, over_data[xmin:xmax][nslice]))
+                local_x = numpy.concatenate((local_x, over_x[nslice] // N_over))
+                local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
+                local_data = numpy.concatenate((local_data, over_data[nslice]))
 
                 c_overs[i] = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(N_over, over_shape[1]))
 
@@ -2093,11 +2093,11 @@ def get_overlaps(
             local_data = over_data[xmin:xmax]
 
             xmin, xmax = bounds_2[2*count:2*(count+1)]
-            nslice = mask_duration[over_sorted[xmin:xmax]]
+            nslice = over_sorted[xmin:xmax][mask_duration[over_sorted[xmin:xmax]]]
 
-            local_x = numpy.concatenate((local_x, over_x[xmin:xmax][nslice] // N_tm))
-            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[xmin:xmax][nslice]))
-            local_data = numpy.concatenate((local_data, over_data[xmin:xmax][nslice]))
+            local_x = numpy.concatenate((local_x, over_x[nslice] // N_tm))
+            local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
+            local_data = numpy.concatenate((local_data, over_data[nslice]))
 
             data = scipy.sparse.csr_matrix((local_data, (local_x, local_y)), shape=(N_tm, over_shape[1]), dtype=numpy.float32)
             maxoverlaps[count, :] = data.max(1).toarray().flatten()[:N_half]

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -570,7 +570,7 @@ def load_data_memshared(
                     del local_x, local_y, local_data, nslice
 
             if local_rank == 0:
-                del over_x, over_y, over_data
+                del over_x, over_y, over_data, over_sorted, sub_over
 
             gc.collect()
 

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -1037,7 +1037,7 @@ def load_data(params, data, extension=''):
             over_data = myfile.get('over_data')[:].ravel()
             over_shape = myfile.get('over_shape')[:].ravel()
             over_sub = numpy.mod(over_x, int(numpy.sqrt(over_shape[0])))
-            over_sorted = numpy.argsort(over_sub).astype(numpy.float32)
+            over_sorted = numpy.argsort(over_sub).astype(numpy.int32)
             myfile.close()
             return over_x, over_y, over_data, over_sub, over_sorted, over_shape
         else:
@@ -2030,7 +2030,7 @@ def get_overlaps(
         # We sort by x indices for faster retrieval later
         if comm.rank == 0:
             if key == 'x':
-                indices = numpy.argsort(data)
+                indices = numpy.argsort(data).astype(numpy.int32)
             data = data[indices]
 
             if hdf5_compress:
@@ -2113,7 +2113,7 @@ def get_overlaps(
             indices = []
             for idx in range(comm.size):
                 indices += list(numpy.arange(idx, N_half, comm.size))
-            indices = numpy.argsort(indices)
+            indices = numpy.argsort(indices).astype(numpy.int32)
 
             maxlags = maxlags[indices, :]
             maxlags[line, line] = 0
@@ -2131,7 +2131,7 @@ def get_overlaps(
             indices = []
             for idx in range(comm.size):
                 indices += list(numpy.arange(idx, N_half, comm.size))
-            indices = numpy.argsort(indices)
+            indices = numpy.argsort(indices).astype(numpy.int32)
 
             maxoverlaps = maxoverlaps[indices, :]
             maxoverlaps[line, line] = 0

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -483,7 +483,7 @@ def load_data_memshared(
                 over_x = c_overlap.get('over_x')[:]
                 over_y = c_overlap.get('over_y')[:]
                 over_data = c_overlap.get('over_data')[:]
-                nb_data = len(over_x) * 2 + N_over
+                nb_data = len(over_x) * 2
 
             c_overlap.close()
 
@@ -520,6 +520,7 @@ def load_data_memshared(
             if local_rank == 0:
                 bounds = numpy.searchsorted(over_x, res, 'left')
                 sub_over = numpy.mod(over_x, N_over)
+                mask_duration = (over_y < duration)
 
             for i in range(N_over):
 
@@ -529,7 +530,7 @@ def load_data_memshared(
                     local_y = over_y[xmin:xmax]
                     local_data = over_data[xmin:xmax]
 
-                    nslice = (sub_over == i) & (over_y < duration)
+                    nslice = (sub_over == i) & mask_duration
                     local_x = numpy.concatenate((local_x, over_x[nslice] / N_over))
                     local_y = numpy.concatenate((local_y, (over_shape[1] - 1) - over_y[nslice]))
                     local_data = numpy.concatenate((local_data, over_data[nslice]))
@@ -574,7 +575,7 @@ def load_data_memshared(
 
             c_overlap = h5py.File(file_name, 'r')
             over_shape = c_overlap.get('over_shape')[:]
-            N_over = over_shape[0]
+            N_over = int(numpy.sqrt(over_shape[0]))
             S_over = over_shape[1]
             c_overs = {}
             indices_bytes = 0


### PR DESCRIPTION
Saving only half the overlaps, using internal symmetries to reconstruct it. Consuming thus less memory and disk space