### PR TITLE
Fitting

### DIFF
--- a/changelog
+++ b/changelog
@@ -12,6 +12,7 @@ Release 1.0.0
 * fix in the MATLAB Gui if no spikes are found
 * support for the maxwell file format (MaxOne and MaxTwo)
 * optimizations for faster fitting
+* templates are densified dring fitting if not enough sparse (faster)
 
 =============
 Release 0.9.9

--- a/circus/fitting.py
+++ b/circus/fitting.py
@@ -89,7 +89,7 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
         is_sparse = sparsity < sparse_threshold
         if not is_sparse:
             if comm.rank == 0:
-                print_and_log(['Templates not sparse enough (%g), densify to speedup the algorithm' %sparsity], 'default', logger)
+                print_and_log(['Templates sparsity is low (%g): densified to speedup the algorithm' %sparsity], 'debug', logger)
             templates = templates.toarray()
 
     temp_2_shift = 2 * template_shift

--- a/circus/fitting.py
+++ b/circus/fitting.py
@@ -149,6 +149,11 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
     if use_gpu:
         templates = cmt.SparseCUDAMatrix(templates, copy_on_host=False)
 
+    #N_tm, x = templates.shape    
+    #sparsity_factor = templates.nnz / (N_tm * x)
+    #if sparsity_factor > 0.2:
+    #    templates = templates.toarray()
+
     info_string = ''
 
     if comm.rank == 0:
@@ -471,6 +476,8 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
             idx_flatten = numpy.arange(flatten_data.size)
             idx_lookup = idx_flatten.reshape(n_tm, nb_local_peak_times)
 
+            to_add_test = np.zeros((b.shape[0], s_over), dtype=np.float32)
+
             while numpy.mean(failure) < total_nb_chances:
 
                 # Is there a way to update sub_b * mask at the same time?
@@ -539,11 +546,8 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
                     peak_time_step = local_peaktimes[peak_index]
 
                     peak_data = (local_peaktimes - peak_time_step).astype(np.int32)
-                    is_neighbor = np.where(np.abs(peak_data) <= temp_2_shift)[0]
+                    is_neighbor = np.abs(peak_data) <= temp_2_shift
                     idx_neighbor = peak_data[is_neighbor] + temp_2_shift
-                    nb_neighbors = len(is_neighbor)
-                    indices = np.zeros((s_over, nb_neighbors), dtype=np.int32)
-                    indices[idx_neighbor, np.arange(nb_neighbors)] = 1
 
                     if full_gpu:
                         indices = cmt.CUDAMatrix(indices, copy_on_host=False)

--- a/circus/fitting.py
+++ b/circus/fitting.py
@@ -150,12 +150,12 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
     if use_gpu:
         templates = cmt.SparseCUDAMatrix(templates, copy_on_host=False)
 
-    N_tm, x = templates.shape
-    sparsity_factor = templates.nnz / (N_tm * x)
-    if sparsity_factor > sparse_threshold:
-        if comm.rank == 0:
-            print_and_log(['Templates are not sparse enough, we densify them for speedup'], 'default', logger)
-        templates = templates.toarray()
+    #N_tm, x = templates.shape
+    #sparsity_factor = templates.nnz / (N_tm * x)
+    #if sparsity_factor > sparse_threshold:
+    #    if comm.rank == 0:
+    #        print_and_log(['Templates are not sparse enough, we densify them for'], 'default', logger)
+    #    templates = templates.toarray()
 
     info_string = ''
 
@@ -553,6 +553,9 @@ def main(params, nb_cpu, nb_gpu, use_gpu):
                     idx_neighbor = peak_data[is_neighbor] + temp_2_shift
 
                     if full_gpu:
+                        nb_neighbors = numpy.sum(is_neighbor)
+                        indices = np.zeros((s_over, nb_neighbors), dtype=np.int32)
+                        indices[idx_neighbor, np.arange(nb_neighbors)] = 1
                         indices = cmt.CUDAMatrix(indices, copy_on_host=False)
                         if patch_gpu:
                             b_lines = b.get_col_slice(0, b.shape[0])

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -504,7 +504,7 @@ def load_data_memshared(
             if is_sparse:
                 to_return = (win_data, win_indices)
             else:
-                to_return = (win_data)
+                to_return = (win_data, )
 
             return templates, to_return
         else:

--- a/circus/shared/files.py
+++ b/circus/shared/files.py
@@ -388,7 +388,7 @@ def get_artefact(params, times_i, tau, nodes):
 
 def load_data_memshared(
         params, data, extension='', normalize=False, transpose=False,
-        nb_cpu=1, nb_gpu=0, use_gpu=False):
+        nb_cpu=1, nb_gpu=0, use_gpu=False, sparse_threshold = 0.2):
 
     file_out = params.get('data', 'file_out')
     file_out_suff = params.get('data', 'file_out_suff')
@@ -406,64 +406,104 @@ def load_data_memshared(
         file_name = file_out_suff + '.templates%s.hdf5' % extension
         if os.path.exists(file_name):
 
-            nb_data = 0
+            nb_data = len(h5py.File(file_name, 'r', libver='earliest').get('temp_data'))
+            nb_templates = h5py.File(file_name, 'r', libver='earliest').get('norms').shape[0]
+            sparsity = nb_data / (N_e * N_t * nb_templates)
+            is_sparse = sparsity < sparse_threshold
+
             nb_ptr = 0
             indptr_bytes = 0
             indices_bytes = 0
             data_bytes = 0
-            nb_templates = h5py.File(file_name, 'r', libver='earliest').get('norms').shape[0]
 
             if local_rank == 0:
                 temp_x = h5py.File(file_name, 'r', libver='earliest').get('temp_x')[:].ravel()
                 temp_y = h5py.File(file_name, 'r', libver='earliest').get('temp_y')[:].ravel()
                 temp_data = h5py.File(file_name, 'r', libver='earliest').get('temp_data')[:].ravel()
-                sparse_mat = scipy.sparse.csc_matrix((temp_data, (temp_x, temp_y)), shape=(N_e*N_t, nb_templates))
+
+                if not is_sparse:
+                    print_and_log(['Templates not sparse enough (%g), densify to speedup the algorithm' %sparsity], 'default', logger)
+                    sparse_mat = numpy.zeros((N_e*N_t, nb_templates), dtype=numpy.float32)
+                    sparse_mat[temp_x, temp_y] = temp_data
+                else:
+                    sparse_mat = scipy.sparse.csc_matrix((temp_data, (temp_x, temp_y)), shape=(N_e*N_t, nb_templates))
+
                 if normalize:
                     norm_templates = load_data(params, 'norm-templates')
-                    for idx in range(sparse_mat.shape[1]):
-                        myslice = numpy.arange(sparse_mat.indptr[idx], sparse_mat.indptr[idx+1])
-                        sparse_mat.data[myslice] /= norm_templates[idx]
+                    if is_sparse:
+                        for idx in range(sparse_mat.shape[1]):
+                            myslice = numpy.arange(sparse_mat.indptr[idx], sparse_mat.indptr[idx+1])
+                            sparse_mat.data[myslice] /= norm_templates[idx]
+                    else:
+                        for idx in range(sparse_mat.shape[1]):
+                            sparse_mat[:, idx] /= norm_templates[idx]
+
                 if transpose:
                     sparse_mat = sparse_mat.T
 
-                nb_data = len(sparse_mat.data)
-                nb_ptr = len(sparse_mat.indptr)
+                if is_sparse:
+                    nb_data = len(sparse_mat.data)
+                else:
+                    nb_data = sparse_mat.size
+
+                if is_sparse:
+                    nb_ptr = len(sparse_mat.indptr)
 
             long_size = numpy.int64(sub_comm.bcast(numpy.array([nb_data], dtype=numpy.int32), root=0)[0])
-            short_size = numpy.int64(sub_comm.bcast(numpy.array([nb_ptr + nb_data], dtype=numpy.int32), root=0)[0])
+
+            if is_sparse:
+                short_size = numpy.int64(sub_comm.bcast(numpy.array([nb_ptr + nb_data], dtype=numpy.int32), root=0)[0])
 
             if local_rank == 0:
-                indices_bytes = short_size * intsize
+                if is_sparse:
+                    indices_bytes = short_size * intsize
                 data_bytes = long_size * floatsize
 
             win_data = MPI.Win.Allocate_shared(data_bytes, floatsize, comm=sub_comm)
-            win_indices = MPI.Win.Allocate_shared(indices_bytes + indptr_bytes, intsize, comm=sub_comm)
+            if is_sparse:
+                win_indices = MPI.Win.Allocate_shared(indices_bytes + indptr_bytes, intsize, comm=sub_comm)
 
             buf_data, _ = win_data.Shared_query(0)
-            buf_indices, _ = win_indices.Shared_query(0)
+            if is_sparse:
+                buf_indices, _ = win_indices.Shared_query(0)
 
             buf_data = numpy.array(buf_data, dtype='B', copy=False)
-            buf_indices = numpy.array(buf_indices, dtype='B', copy=False)
+            if is_sparse:
+                buf_indices = numpy.array(buf_indices, dtype='B', copy=False)
 
             data = numpy.ndarray(buffer=buf_data, dtype=numpy.float32, shape=(long_size,))
-            indices = numpy.ndarray(buffer=buf_indices, dtype=numpy.int32, shape=(short_size,))
+            if is_sparse:
+                indices = numpy.ndarray(buffer=buf_indices, dtype=numpy.int32, shape=(short_size,))
 
             if local_rank == 0:
-                data[:] = sparse_mat.data
-                indices[:long_size] = sparse_mat.indices
-                indices[long_size:] = sparse_mat.indptr
+                if is_sparse:
+                    data[:] = sparse_mat.data
+                    indices[:long_size] = sparse_mat.indices
+                    indices[long_size:] = sparse_mat.indptr
+                else:
+                    data[:] = sparse_mat.ravel()
                 del sparse_mat
 
             if not transpose:
-                templates = scipy.sparse.csc_matrix((N_e * N_t, nb_templates), dtype=numpy.float32)
+                if is_sparse:
+                    templates = scipy.sparse.csc_matrix((N_e * N_t, nb_templates), dtype=numpy.float32)
             else:
-                templates = scipy.sparse.csr_matrix((nb_templates, N_e * N_t), dtype=numpy.float32)
+                if is_sparse:
+                    templates = scipy.sparse.csr_matrix((nb_templates, N_e * N_t), dtype=numpy.float32)
 
-            templates.data = data
-            templates.indices = indices[:long_size]
-            templates.indptr = indices[long_size:]
+            if is_sparse:
+                templates.data = data
+                templates.indices = indices[:long_size]
+                templates.indptr = indices[long_size:]
+            else:
+                templates = data.reshape(N_e*N_t, nb_templates)
 
-            return templates, (win_data, win_indices)
+            if is_sparse:
+                to_return = (win_data, win_indices)
+            else:
+                to_return = (win_data)
+
+            return templates, to_return
         else:
             if comm.rank == 0:
                 print_and_log(["No templates found! Check suffix?"], 'error', logger)

--- a/circus/shared/parser.py
+++ b/circus/shared/parser.py
@@ -90,6 +90,7 @@ class CircusParser(object):
                           ['fitting', 'ratio_thresh', 'float', '0.9'],
                           ['fitting', 'two_components', 'bool', 'True'],
                           ['fitting', 'auto_nb_chances', 'bool', 'True'],
+                          ['fitting', 'sparse_thresh', 'float', '0.2'],
                           ['data', 'global_tmp', 'bool', 'True'],
                           ['data', 'chunk_size', 'int', '30'],
                           ['data', 'stream_mode', 'string', 'None'],


### PR DESCRIPTION
Automatically make the templates dense if sparsity is below a certain threshold (by default, 0.2). This is because sparse dot products are much slower in scipy (not using BLAS), and thus if we can not save memory, at least we can be faster.