### PR TITLE
fix(hdf5): fixed the use of a custom hdf5 filter

### DIFF
--- a/docker/parallel_hdf5/Dockerfile
+++ b/docker/parallel_hdf5/Dockerfile
@@ -4,7 +4,7 @@ FROM continuumio/miniconda3
 
 #########################################
 ### Python, etc                                                                                                                
-RUN apt-get update && apt-get -y install git wget build-essential
+RUN apt-get update && apt-get -y install git wget build-essential zlib1g-dev
 RUN apt-get install -y python3 python3-pip
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-tk
 
@@ -13,26 +13,30 @@ RUN apt-get update && apt-get install -y libmpich-dev mpich \
     libglib2.0-0 libgl1-mesa-glx \ 
     packagekit-gtk3-module libcanberra-gtk-module libcanberra-gtk3-module
 
+# build prerequisite for HDF (and Spyking Circus)
+RUN pip3 install cmake
+
 #########################################
 ### Parallel HDF
 RUN echo "Installing Parallel HDF..."
 
+# h5py variables
 ENV CC=mpicc
 ENV HDF5_MPI="ON"
 # where parallel hdf5 will be built
-ENV HDF5_DIR="/root/hdf5-1.12.0/hdf5"
+ENV HDF5_DIR="/root/CMake-hdf5-1.12.0/HDF5-1.12.0-Linux/HDF_Group/HDF5/1.12.0/"
 
 WORKDIR /root
 
-RUN wget -O hdf5.tar.gz https://www.hdfgroup.org/package/hdf5-1-12-0-tar-gz/?wpdmdl=14582
+RUN wget -O hdf5.tar.gz https://www.hdfgroup.org/package/cmake-hdf5-1-12-0-tar-gz/?wpdmdl=14580
 
 RUN tar -xf hdf5.tar.gz
 
-WORKDIR /root/hdf5-1.12.0
+WORKDIR /root/CMake-hdf5-1.12.0
 
-RUN ./configure --enable-parallel --enable-shared && \
-    make && \
-    make install
+RUN ctest -S HDF5config.cmake,MPI=true,BUILD_GENERATOR=Unix -C Release -V -O hdf5.log
+
+RUN tar -xf HDF5-1.12.0-Linux.tar.gz
 
 WORKDIR /root
 
@@ -44,7 +48,6 @@ RUN pip3 install --no-binary=h5py h5py
 RUN echo "Installing SpyKING CIRCUS and phy 2.0..."
 
 RUN pip3 install scikit-build
-RUN pip3 install cmake
 RUN pip3 install spyking-circus
 
 ### Phy
@@ -52,4 +55,3 @@ RUN pip3 install colorcet pyopengl qtconsole requests traitlets tqdm joblib clic
 # this is why we use `continuumio/miniconda3` instead of ubuntu:18.04
 RUN conda install pyqt cython pillow 
 RUN pip3 install phy --pre --upgrade
-


### PR DESCRIPTION
Previously, trying a custom filter may have resulted in a segmentation fault.

Now, using the recommended CMake build tool for HDF5, these custom filters can be used.

MPI support is maintained.

Tested with custom `mxw-data` filter.