### PR TITLE
Allow data_path to be set via environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,14 @@ def read(fname):
 if sys.version_info < (2, 7):
     raise RuntimeError('Only Python versions >= 2.7 are supported')
 
-if 'CONDA_BUILD' in os.environ and 'RECIPE_DIR' in os.environ:
-    # We seem to be running under a "conda build"
-    data_path = pjoin('data', 'spyking-circus')
-else:
-    data_path = pjoin(os.path.expanduser('~'), 'spyking-circus')
+try:
+    data_path = os.environ['SPYKING_CIRCUS_DATA_PATH']
+except KeyError:
+    if 'CONDA_BUILD' in os.environ and 'RECIPE_DIR' in os.environ:
+        # We seem to be running under a "conda build"
+        data_path = pjoin('data', 'spyking-circus')
+    else:
+        data_path = pjoin(os.path.expanduser('~'), 'spyking-circus')
 
 
 def _package_tree(pkgroot):


### PR DESCRIPTION
If `SPYKING_CIRCUS_DATA_PATH` is in the environment during `setup.py` invocation, the `data_path` is taken from its value.

This would allow Fedora Linux to drop a dowstream patch that hard-codes an appropriate system-wide data path (`/usr/share/spyking-circus`) and instead just export `SPYKING_CIRCUS_DATA_PATH=/usr/share/spyking-circus`. It would be similarly useful to other distributions that might package this software, and it might be useful to some other users as well.