### PR TITLE
Fix a doc typo: “CIRUCS” for “CIRCUS”

### DIFF
--- a/docs_sphinx/GUI/launching.rst
+++ b/docs_sphinx/GUI/launching.rst
@@ -9,7 +9,7 @@ Matlab GUI
 Installing MATLAB
 ~~~~~~~~~~~~~~~~~
 
-SpyKING CIRUCS will assume that you have a valid installation of MATLAB, and that the matlab command can be found in the system $PATH. For windows user, please have a look to this `howto <https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/>`_. For unix users (mac or linux), simply add the following line to your .bash_profile or .bashrc file, in your $HOME directory::
+SpyKING CIRCUS will assume that you have a valid installation of MATLAB, and that the matlab command can be found in the system $PATH. For windows user, please have a look to this `howto <https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/>`_. For unix users (mac or linux), simply add the following line to your .bash_profile or .bashrc file, in your $HOME directory::
 
     export PATH=$PATH:/PATH_TO_YOUR_MATLAB/bin
 


### PR DESCRIPTION
Fixes a trivial typo in the Sphinx documentation.